### PR TITLE
Error 1 en issue 72 A

### DIFF
--- a/colabora/db.py
+++ b/colabora/db.py
@@ -138,6 +138,15 @@ def cantidad_asignadas_por_usuario(db, entidad, legislatura):
     cur.execute(cmd,(legislatura,))
     records = cur.fetchall()
     asignadas = dict()
+
+    if not records:
+        asignadas[''] = dict()
+        asignadas['']['Total'] = 0
+        asignadas['']['Nueva'] = 0
+        asignadas['']['Pendiente'] = 0
+        asignadas['']['Revisada'] = 0
+        return asignadas
+    
     for row in records:
         usuario = row['usuario']
         estado = row['estado']

--- a/tests/data.sql
+++ b/tests/data.sql
@@ -23,6 +23,9 @@ VALUES ('usuario3', 'admin', 'contrasena3:hashed', 1);
 INSERT INTO usuarios (usuario, rol, contrasena, legislatura_id)
 VALUES ('usuario4', 'escritor', 'contrasena4:hashed', 1);
 
+INSERT INTO usuarios (usuario_id, usuario, rol, contrasena, legislatura_id)
+VALUES (6, 'usuario6', 'admin', 'contrasena6:hashed', 2);
+
 INSERT INTO iniciativas (legislatura_id, numero,
 cambios, documento, tema, resumen, comentario)
 VALUES

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -67,7 +67,7 @@ def test_usuario_no_encontrado(database):
 def test_usuarios(database):
     database.executescript(_data_sql)
     result = colabora.db.usuarios(database)
-    assert len(result) == 4
+    assert len(result) == 5
     assert "usuario1" == result[0]["usuario"]
     assert "escritor" == result[0]["rol"]
     assert 1 == result[0]["usuario_id"]

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -143,6 +143,12 @@ def test_cantidad_asignadas_por_usuario(database):
     assert result['usuario1']['Pendiente'] == 0
     assert result['usuario1']['Revisada'] == 0
 
+def test_cantidad_asignadas_por_usuario_sin_iniciativas(database):
+    database.executescript(_data_sql)
+    result = colabora.db.cantidad_asignadas_por_usuario(database, entidad= 'entidad1', legislatura= 'legislatura2')
+    assert len(result) == 1
+    assert result == {'': {'Total': 0, 'Nueva': 0, 'Pendiente': 0, 'Revisada': 0}}
+
 def test_asignadas_por_usuario(database):
     database.executescript(_data_sql)
     result = colabora.db.asignadas_por_usuario(database, 'entidad1', 'legislatura1')


### PR DESCRIPTION
## Descripción:
Se agregó un manejo para el caso de que no haya iniciativas en una legislatura.

## Cambios realizados:
Agregar un usuario a data.sql con una legislatura vacía, agregar el caso en el que no se encuentren iniciativas con la legislatura y devolver correctamente las asignadas en el formato esperado.

## Razón de la modificación:
Mostrar correctamente en la interfaz que no existen iniciativas en la legislatura.