### PR TITLE
Issue 72 A - Error 1

### DIFF
--- a/colabora/db.py
+++ b/colabora/db.py
@@ -139,13 +139,11 @@ def cantidad_asignadas_por_usuario(db, entidad, legislatura):
     records = cur.fetchall()
     asignadas = dict()
 
-    if not records:
-        asignadas[''] = dict()
-        asignadas['']['Total'] = 0
-        asignadas['']['Nueva'] = 0
-        asignadas['']['Pendiente'] = 0
-        asignadas['']['Revisada'] = 0
-        return asignadas
+    asignadas[''] = dict()
+    asignadas['']['Total'] = 0
+    asignadas['']['Nueva'] = 0
+    asignadas['']['Pendiente'] = 0
+    asignadas['']['Revisada'] = 0
     
     for row in records:
         usuario = row['usuario']

--- a/tests/data.sql
+++ b/tests/data.sql
@@ -3,6 +3,7 @@ INSERT INTO entidad (nombre) VALUES ('entidad2');
 INSERT INTO legislatura (nombre, entidad_id) VALUES ('legislatura1', 1);
 INSERT INTO legislatura (nombre, entidad_id) VALUES ('legislatura2', 1);
 INSERT INTO legislatura (nombre, entidad_id) VALUES ('legislatura1', 2);
+INSERT INTO legislatura (nombre, entidad_id) VALUES ('legislatura3', 1);
 INSERT INTO estado (estado) VALUES ('estado1');
 
 INSERT INTO areas (nombre)
@@ -40,6 +41,13 @@ VALUES
  3, 'Cambios 3', 'documento3', 'tema3', 'resumen3', 'comentario3'
 );
 
+INSERT INTO iniciativas (legislatura_id, numero,
+cambios, documento, tema, resumen, comentario)
+VALUES
+((SELECT legislatura_id FROM legislatura WHERE nombre='legislatura3'),
+ 4, 'Cambios 4', 'documento4', 'tema4', 'resumen4', 'comentario4'
+);
+
 INSERT INTO clasificacion (legislatura_id, numero, area_id) VALUES
 ((SELECT legislatura_id FROM legislatura WHERE nombre='legislatura1'),
  3,
@@ -61,5 +69,11 @@ INSERT INTO clasificacion (legislatura_id, numero, area_id) VALUES
 INSERT INTO asignacion (legislatura_id, numero, usuario_id) VALUES
 ((SELECT legislatura_id FROM legislatura WHERE nombre='legislatura1'),
  1,
+ (SELECT usuario_id FROM usuarios WHERE usuario='usuario1')
+);
+
+INSERT INTO asignacion (legislatura_id, numero, usuario_id) VALUES
+((SELECT legislatura_id FROM legislatura WHERE nombre='legislatura3'),
+ 4,
  (SELECT usuario_id FROM usuarios WHERE usuario='usuario1')
 );

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -383,4 +383,4 @@ def test_remueve_usuario_error(database):
 def test_legislaturas(database):
     database.executescript(_data_sql)
     result = colabora.db.legislaturas(database)
-    assert result == {'entidad1': [('legislatura1', 1), ('legislatura2', 2)], 'entidad2': [('legislatura1', 3)]}
+    assert result == {'entidad1': [('legislatura1', 1), ('legislatura2', 2), ('legislatura3', 4)], 'entidad2': [('legislatura1', 3)]}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -149,6 +149,12 @@ def test_cantidad_asignadas_por_usuario_sin_iniciativas(database):
     assert len(result) == 1
     assert result == {'': {'Total': 0, 'Nueva': 0, 'Pendiente': 0, 'Revisada': 0}}
 
+def test_cantidad_asignadas_por_usuario_todas_asignadas(database):
+    database.executescript(_data_sql)
+    result = colabora.db.cantidad_asignadas_por_usuario(database, entidad= 'entidad1', legislatura= 'legislatura3')
+    assert len(result) == 2
+    assert result == {'': {'Total': 0, 'Nueva': 0, 'Pendiente': 0, 'Revisada': 0}, 'usuario1': {'Total': 1, 'Nueva': 1, 'Pendiente': 0, 'Revisada': 0}}
+
 def test_asignadas_por_usuario(database):
     database.executescript(_data_sql)
     result = colabora.db.asignadas_por_usuario(database, 'entidad1', 'legislatura1')


### PR DESCRIPTION
## Descripción:
Se modificó la función de `db.cantidad_asignadas_por_usuario` para mostrar en cualquier caso la cantidad correcta de las iniciativas sin asignar.

## Cambios realizados:
El usuario vacío para indicar las iniciativas sin asignar se agregó por defecto.

## Razón de la modificación:
Se garantiza de que independientemente de que no existan iniciativas sin asignar, siempre existirá un usuario vacío indicando el total de estas. En el caso de que no hayan iniciativas o que no hayan iniciativas que aún falten de asignar, el resultado será 0 en el total y en caso de haber iniciativas sin asignar, se estarán sumando al total en el bucle de la función.